### PR TITLE
Offload all jsx text indentation handling to indentMultilineCommentOrJsxText

### DIFF
--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -343,24 +343,6 @@ namespace ts.formatting {
             return false;
         }
 
-        export function isJSXClosingWithMultiLineText(parent: Node, child: TextRangeWithKind, _childStartLine: number, sourceFile: SourceFileLike): boolean {
-            if (isJsxElement(parent) && isParenthesizedExpression(parent.parent)) {
-                const siblings = parent.getChildren(sourceFile);
-                const currentNode = find(siblings, arg => arg.pos === child.pos);
-                if (!currentNode) return false;
-
-                const currentIndex = siblings.indexOf(currentNode);
-                if (currentIndex === 0) return false;
-
-                const previousNode = siblings[currentIndex - 1];
-                const startLineOfPreviousNode = getLineAndCharacterOfPosition(sourceFile, previousNode.getStart()).line;
-                const endLineOfPreviousNode = getLineAndCharacterOfPosition(sourceFile, previousNode.getEnd()).line;
-
-                return startLineOfPreviousNode !== endLineOfPreviousNode;
-            }
-            return false;
-        }
-
         export function getContainingList(node: Node, sourceFile: SourceFile): NodeArray<Node> | undefined {
             return node.parent && getListByRange(node.getStart(sourceFile), node.getEnd(), node.parent, sourceFile);
         }


### PR DESCRIPTION
This should fix the remaining test issues your PR had - mostly, now that the scanners' un-borked, it just de-duplicates jsx text indentation handling, so it's only performed by `indentMultilineCommentOrJsxText` (and adjusts it so it reliably re-indents jsx text like we'd like).

Our tests bring up a good question though - as is, this will reformat:
```ts
const d = <div>
My list:
  * A
  * B
  * C
</div>;
```
as
```ts
const d = <div>
    My list:
    * A
    * B
    * C
</div>;
```
which one of the new tests seemed to imply was correct, rather than the probably preferable:
```ts
const d = <div>
    My list:
      * A
      * B
      * C
</div>;
```
I can see why it sort-of is, I guess, but if it's not, and we'd like to reconsider preserving the whitespace on the lines after the first, like we do for comments, we'd just need to remove [this new line](https://github.com/orta/TypeScript/compare/orta:fix_20766...weswigham:small-patch-to-fix?expand=1#diff-270a188d87d631646eabdbdd7b019e3cR1112).